### PR TITLE
Fix the relative error formula

### DIFF
--- a/lbeta_function.ipynb
+++ b/lbeta_function.ipynb
@@ -543,7 +543,7 @@
    "source": [
     "To measure the accuracy of a log-beta function implementation, we use the _relative error_. Let $\\hat{x}$ be an approximation of the real number $x$. The relative error $E_{\\text{rel}}(\\hat{x})$ is given by:\n",
     "\n",
-    "$$E_{\\text{rel}}(\\hat{x}) = \\frac{|x - \\hat{x}|}{x}.$$"
+    "$$E_{\\text{rel}}(\\hat{x}) = \\frac{|x - \\hat{x}|}{|x|}.$$"
    ]
   },
   {


### PR DESCRIPTION
Fix the relative error formula in the file `lbeta_function.ipynb`.