### PR TITLE
Add improvements

### DIFF
--- a/specials/_internal/asserting.mojo
+++ b/specials/_internal/asserting.mojo
@@ -80,7 +80,7 @@ fn assert_positive[parameter_name: StringLiteral, parameter_value: Int]() -> Non
 
 @always_inline("nodebug")
 fn assert_positive[
-    dtype: DType, parameter_name: StringLiteral, parameter_value: SIMD[dtype, 1]
+    dtype: DType, parameter_name: StringLiteral, parameter_value: Scalar[dtype]
 ]() -> None:
     """Asserts the condition `parameter_value > 0` holds."""
     constrained[

--- a/specials/_internal/limits.mojo
+++ b/specials/_internal/limits.mojo
@@ -74,25 +74,25 @@ fn _maxexp_impl[dtype: DType]() -> Int:
         return 1024
 
 
-fn _eps_impl[dtype: DType]() -> SIMD[dtype, 1]:
+fn _eps_impl[dtype: DType]() -> Scalar[dtype]:
     """Computes the floating-point arithmetic parameter `eps`."""
     alias machep = _machep_impl[dtype]()
     return math.ldexp[dtype, 1](1.0, machep)
 
 
-fn _epsneg_impl[dtype: DType]() -> SIMD[dtype, 1]:
+fn _epsneg_impl[dtype: DType]() -> Scalar[dtype]:
     """Computes the floating-point arithmetic parameter `epsneg`."""
     alias negep = _negep_impl[dtype]()
     return math.ldexp[dtype, 1](1.0, negep)
 
 
-fn _min_impl[dtype: DType]() -> SIMD[dtype, 1]:
+fn _min_impl[dtype: DType]() -> Scalar[dtype]:
     """Returns the floating-point arithmetic parameter `min`."""
     alias minexp = _minexp_impl[dtype]()
     return math.ldexp[dtype, 1](1.0, minexp)
 
 
-fn _max_impl[dtype: DType]() -> SIMD[dtype, 1]:
+fn _max_impl[dtype: DType]() -> Scalar[dtype]:
     """Returns the floating-point arithmetic parameter `max`."""
     alias epsneg = _epsneg_impl[dtype]()
     alias maxexp = _maxexp_impl[dtype]()
@@ -126,14 +126,14 @@ struct FloatLimits[dtype: DType]:
     alias maxexp: Int = _maxexp_impl[dtype]()
     """The smallest positive power of the base (2) that causes overflow."""
 
-    alias eps: SIMD[dtype, 1] = _eps_impl[dtype]()
+    alias eps: Scalar[dtype] = _eps_impl[dtype]()
     """The smallest positive floating-point number such that `1.0 + eps != 1.0`."""
 
-    alias epsneg: SIMD[dtype, 1] = _epsneg_impl[dtype]()
+    alias epsneg: Scalar[dtype] = _epsneg_impl[dtype]()
     """The smallest positive floating-point number such that `1.0 - epsneg != 1.0`."""
 
-    alias min: SIMD[dtype, 1] = _min_impl[dtype]()
+    alias min: Scalar[dtype] = _min_impl[dtype]()
     """The smallest positive floating-point number."""
 
-    alias max: SIMD[dtype, 1] = _max_impl[dtype]()
+    alias max: Scalar[dtype] = _max_impl[dtype]()
     """The largest positive floating-point number."""

--- a/specials/_internal/numerics_testing.py
+++ b/specials/_internal/numerics_testing.py
@@ -19,6 +19,13 @@
 # tensorflow/probability:
 # Copyright 2018 The TensorFlow Probability Authors. All rights reserved.
 # Licensed under the Apache License, Version 2.0 (the "License").
+#
+# References:
+#
+# Brown, B. W., & Levy, L. B. (1994). Certification of Algorithm 708:
+#   significant-digit computation of the incomplete beta.
+# ACM Transactions on Mathematical Software (TOMS), 20(3), 393-397.
+# https://dl.acm.org/doi/10.1145/192115.192155
 
 """Numerical testing utilities."""
 
@@ -58,7 +65,7 @@ def py_accuracy_in_significant_digits(relerr):
     which is the usual definition: `n` significant digits of accuracy in a value allows
     an error of `5` in the `(n + l)`st decimal place.
 
-    To avoid taking the logarithm of `O`, the relative error is bounded below by the
+    To avoid taking the logarithm of `0`, the relative error is bounded below by the
     `epsneg` value of `float64`: the smallest positive floating-point number such that
     `1.0 - epsneg != 1.0`.
 

--- a/specials/_internal/numerics_testing.py
+++ b/specials/_internal/numerics_testing.py
@@ -22,6 +22,11 @@
 #
 # References:
 #
+# Beebe, N. H. (2017). The Mathematical-Function Computation Handbook:
+#   Programming Using the MathCW Portable Software Library.
+# Springer International Publishing.
+# https://doi.org/10.1007/978-3-319-64110-2
+#
 # Brown, B. W., & Levy, L. B. (1994). Certification of Algorithm 708:
 #   significant-digit computation of the incomplete beta.
 # ACM Transactions on Mathematical Software (TOMS), 20(3), 393-397.
@@ -33,7 +38,7 @@ import numpy as np
 
 
 def py_relative_error(result, truth):
-    """Computes the relative error of `result` relative `truth`.
+    """Computes the relative error of `result` relative to `truth`.
 
     The relative error is defined as `abs((result - truth) / truth)`. The computation
     of that difference and ratio are done in 64-bit precision.
@@ -79,3 +84,133 @@ def py_accuracy_in_significant_digits(relerr):
     """
     relerr = np.array(relerr, dtype=np.float64)
     return -np.log10(2.0 * np.maximum(relerr, np.finfo(np.float64).epsneg))
+
+
+def py_kahan_ulp(x, output_dtype):
+    """Computes the Kahan-ulp function at `x` element-wise.
+
+    Ulp stands for "unit in the last place".
+
+    If `x` is a floating-point number, the Kahan-ulp at `x` is the distance between
+    the two floating-point numbers nearest `x`, even if `x` is not contained in the
+    interval between them.
+
+    Args:
+        x: Array of floating-point values.
+        output_dtype: Data type of the output array.
+
+    Returns:
+        Array of element-wise Kahan-ulp values.
+
+    Raises:
+        TypeError: If `x.dtype` or `output_dtype` is not a floating-point type.
+        TypeError: If `output_dtype` has higher precision than `x.dtype`.
+    """
+    x = np.array(x)
+
+    dtype = x.dtype
+    output_dtype = np.dtype(output_dtype)
+
+    if dtype.kind != "f":
+        raise TypeError("`x.dtype` must be a floating-point type")
+
+    if output_dtype.kind != "f":
+        raise TypeError("`output_dtype` must be a floating-point type")
+
+    if np.finfo(output_dtype).precision > np.finfo(dtype).precision:
+        raise TypeError("`output_dtype` cannot have higher precision than `x.dtype`")
+
+    dtype = dtype.type
+    output_dtype = output_dtype.type
+
+    xmin = np.finfo(output_dtype).smallest_normal
+    xeps = np.finfo(output_dtype).eps
+    emax = np.finfo(output_dtype).maxexp - 1
+    emin = np.finfo(output_dtype).minexp - 1
+    t = np.finfo(output_dtype).nmant
+    esub = emin - t + 1
+    one = dtype(1.0)
+
+    result = np.empty_like(x)
+    result = np.where(np.isnan(x.astype(output_dtype)), np.nan, result)
+    result = np.where(
+        np.isinf(x.astype(output_dtype)), np.ldexp(one, emax - t + 1), result
+    )
+    result = np.where(np.abs(x) <= xmin, np.ldexp(one, esub), result)
+
+    is_main_branch = np.isfinite(x.astype(output_dtype)) & (np.abs(x) > xmin)
+    y = np.where(is_main_branch, x, one)
+
+    _, e = np.frexp(y)
+    s = np.ldexp(np.abs(y), -e)
+    e -= t - 1
+
+    e = np.where((s - one) < (0.5 * xeps), e - 1, e)
+    e = np.maximum(e, esub)
+    result = np.where(is_main_branch, np.ldexp(one, e), result)
+
+    result = result.astype(output_dtype)
+    result = np.where(result == 0.0, xmin, result)
+
+    if result.shape == ():
+        return output_dtype(result.item(0))
+
+    return result
+
+
+def _promote_dtype(dtype):
+    """Promotes `dtype` to a higher precision floating-point type."""
+    dtype = np.dtype(dtype)
+    if dtype.kind != "f":
+        raise TypeError("`dtype` must be a floating-point type")
+
+    if np.finfo(dtype).bits < 32:
+        return np.float32
+
+    if np.finfo(dtype).bits < 64:
+        return np.float64
+
+    if np.finfo(dtype).bits < 128:
+        return np.float128
+
+    return dtype
+
+
+def py_error_in_ulps(result, truth):
+    """Computes the error in ulps of `result` relative to `truth`.
+
+    Ulp stands for "unit in the last place".
+
+    The error in ulps is defined as `abs((result - truth) / kahan_ulp(truth))`. See the
+    `kahan_ulp` function for more details.
+
+    If `truth.dtype` is not a floating-point type, it is cast to the following type:
+        - `np.float32` if `result.dtype.bits < 32`;
+        - `np.float64` if `32 <= result.dtype.bits < 64`;
+        - `np.float128` if `64 <= result.dtype.bits < 128`; or
+        - `result.dtype` otherwise.
+
+    Args:
+        result: Array of values whose deviation to assess.
+        truth: Array of values presumed correct. Must broadcast with `result`.
+
+    Returns:
+        Array of element-wise error in ulps values.
+
+    Raises:
+        TypeError: If `result.dtype` is not a floating-point type.
+        TypeError: If `result.dtype` has higher precision than `truth.dtype`.
+    """
+    result = np.array(result)
+
+    if result.dtype.kind != "f":
+        raise TypeError("`result.dtype` must be a floating-point type")
+
+    truth = np.array(truth)
+
+    if truth.dtype.kind != "f":
+        truth = truth.astype(_promote_dtype(result.dtype))
+
+    ulp_truth = py_kahan_ulp(truth, output_dtype=result.dtype)
+
+    return np.abs((result - truth).astype(result.dtype) / ulp_truth)

--- a/specials/_internal/numerics_testing_test.py
+++ b/specials/_internal/numerics_testing_test.py
@@ -17,15 +17,17 @@
 """Tests for numerical testing utilities."""
 
 import numpy as np
+import pytest
 
-from numerics_testing import py_relative_error, py_accuracy_in_significant_digits
+
+import numerics_testing
 
 
 def test_py_relative_error():
     result = np.array([0.0, 1.1, 2.0, 3.0])
     truth = np.array([0.0, 1.0, 0.0, 3.0])
 
-    actual = py_relative_error(result, truth)
+    actual = numerics_testing.py_relative_error(result, truth)
     expected = np.array([0.0, 0.1, np.inf, 0.0])
 
     np.testing.assert_allclose(actual, expected, rtol=1e-15, atol=0.0)
@@ -34,9 +36,117 @@ def test_py_relative_error():
 def test_py_accuracy_in_significant_digits():
     relerr = np.array([0.0, 0.1, np.inf, 0.0])
 
-    actual = py_accuracy_in_significant_digits(relerr)
+    actual = numerics_testing.py_accuracy_in_significant_digits(relerr)
     expected = np.array(
         [15.653559774527022, 0.6989700043360187, -np.inf, 15.653559774527022]
     )
 
     np.testing.assert_allclose(actual, expected, rtol=1e-15, atol=0.0)
+
+
+@pytest.mark.parametrize(
+    "x, output_dtype, expected",
+    [
+        (
+            np.array(
+                [np.nan, -1.0, 0.0, 1.0, np.finfo(np.float64).max, np.inf],
+                dtype=np.float128,
+            ),
+            np.float64,
+            np.array(
+                [
+                    np.nan,
+                    4.440892098500626e-16,
+                    5e-324,
+                    4.440892098500626e-16,
+                    3.99168061906944e292,
+                    3.99168061906944e292,
+                ],
+                dtype=np.float64,
+            ),
+        ),
+        (
+            np.array(
+                [np.nan, -1.0, 0.0, 1.0, np.finfo(np.float32).max, np.inf],
+                dtype=np.float64,
+            ),
+            np.float32,
+            np.array(
+                [
+                    np.nan,
+                    2.3841858e-07,
+                    1e-45,
+                    2.3841858e-07,
+                    4.056482e31,
+                    4.056482e31,
+                ],
+                dtype=np.float32,
+            ),
+        ),
+    ],
+)
+def test_py_kahan_ulp(x, output_dtype, expected):
+    actual = numerics_testing.py_kahan_ulp(x, output_dtype)
+
+    if output_dtype == np.float32:
+        np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=0.0)
+    else:
+        np.testing.assert_allclose(actual, expected, rtol=1e-15, atol=0.0)
+
+
+def test_py_kahan_ulp_invalid_dtype():
+    x = np.array([0.0, 1.0], dtype=np.int64)
+    output_dtype = np.float32
+
+    with pytest.raises(TypeError):
+        numerics_testing.py_kahan_ulp(x, output_dtype)
+
+
+def test_py_kahan_ulp_invalid_output_dtype():
+    x = np.array([0.0, 1.0], dtype=np.float64)
+    output_dtype = np.int32
+
+    with pytest.raises(TypeError):
+        numerics_testing.py_kahan_ulp(x, output_dtype)
+
+
+def test_py_kahan_ulp_higher_precision_output_dtype():
+    x = np.array([0.0, 1.0], dtype=np.float32)
+    output_dtype = np.float64
+
+    with pytest.raises(TypeError):
+        numerics_testing.py_kahan_ulp(x, output_dtype)
+
+
+@pytest.mark.parametrize(
+    "result, truth, expected",
+    [
+        (np.float64(1.0) + np.finfo(np.float64).eps, np.float128(1.0), np.float64(0.5)),
+        (np.float64(1.0) + np.finfo(np.float64).eps, np.float64(1.0), np.float64(0.5)),
+        (np.float64(1.0) + np.finfo(np.float64).eps, np.int64(1), np.float64(0.5)),
+        (np.float32(1.0) + np.finfo(np.float32).eps, np.float64(1.0), np.float32(0.5)),
+    ],
+)
+def test_py_error_in_ulps(result, truth, expected):
+    actual = numerics_testing.py_error_in_ulps(result, truth)
+
+    if result.dtype == np.float32:
+        np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=0.0)
+    else:
+        np.testing.assert_allclose(actual, expected, rtol=1e-15, atol=0.0)
+
+
+def test_py_error_in_ulps_invalid_dtype():
+    result = np.int32(1)
+    truth = np.float64(1.0)
+
+    with pytest.raises(TypeError):
+        numerics_testing.py_error_in_ulps(result, truth)
+
+
+def test_py_error_in_ulps_higher_precision_result_dtype():
+    result = np.float64(1)
+    truth = np.float32(1.0)
+
+    with pytest.raises(TypeError):
+        numerics_testing.py_error_in_ulps(result, truth)

--- a/specials/_internal/numerics_testing_test.py
+++ b/specials/_internal/numerics_testing_test.py
@@ -1,0 +1,42 @@
+# ===----------------------------------------------------------------------=== #
+# Copyright 2024 The Specials Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===----------------------------------------------------------------------=== #
+
+"""Tests for numerical testing utilities."""
+
+import numpy as np
+
+from numerics_testing import py_relative_error, py_accuracy_in_significant_digits
+
+
+def test_py_relative_error():
+    result = np.array([0.0, 1.1, 2.0, 3.0])
+    truth = np.array([0.0, 1.0, 0.0, 3.0])
+
+    actual = py_relative_error(result, truth)
+    expected = np.array([0.0, 0.1, np.inf, 0.0])
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-15, atol=0.0)
+
+
+def test_py_accuracy_in_significant_digits():
+    relerr = np.array([0.0, 0.1, np.inf, 0.0])
+
+    actual = py_accuracy_in_significant_digits(relerr)
+    expected = np.array(
+        [15.653559774527022, 0.6989700043360187, -np.inf, 15.653559774527022]
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-15, atol=0.0)

--- a/specials/_internal/polynomial.mojo
+++ b/specials/_internal/polynomial.mojo
@@ -55,7 +55,7 @@ struct Chebyshev[
     num_terms: Int,
     dtype: DType,
     simd_width: Int,
-]:
+](Sized):
     """Represents a finite Chebyshev series.
 
     A Chebyshev series with `n + 1` terms is a polynomial of the form
@@ -143,6 +143,17 @@ struct Chebyshev[
             splatted_coefficients[i] = bitcast[dtype](coefficients[i])
 
         return Self {_coefficients: splatted_coefficients}
+
+    @always_inline
+    fn __len__(self: Self) -> Int:
+        """Returns the number of terms in the Chebyshev series.
+
+        This is known at compile time.
+
+        Returns:
+            The number of terms in the Chebyshev series.
+        """
+        return num_terms
 
     @always_inline
     fn degree(self: Self) -> Int:
@@ -290,7 +301,7 @@ struct Polynomial[
     num_terms: Int,
     dtype: DType,
     simd_width: Int,
-]:
+](Sized):
     """Represents a finite Power series, commonly known as a polynomial.
 
     A Power series with `n + 1` terms is a polynomial of the form
@@ -377,6 +388,17 @@ struct Polynomial[
             splatted_coefficients[i] = bitcast[dtype](coefficients[i])
 
         return Self {_coefficients: splatted_coefficients}
+
+    @always_inline
+    fn __len__(self: Self) -> Int:
+        """Returns the number of terms in the Power series.
+
+        This is known at compile time.
+
+        Returns:
+            The number of terms in the Power series.
+        """
+        return num_terms
 
     @always_inline
     fn degree(self: Self) -> Int:

--- a/specials/_internal/polynomial.mojo
+++ b/specials/_internal/polynomial.mojo
@@ -97,7 +97,7 @@ struct Chebyshev[
     var _coefficients: StaticTuple[num_terms, SIMD[dtype, simd_width]]
 
     @staticmethod
-    fn from_coefficients[*coefficients: SIMD[dtype, 1]]() -> Self:
+    fn from_coefficients[*coefficients: Scalar[dtype]]() -> Self:
         """Generates a Chebyshev series from a sequence of coefficients.
 
         Parameters:
@@ -249,7 +249,7 @@ struct Chebyshev[
 
         return math.select(math.abs(x) > 1.0, nan, result)
 
-    fn economize[error_tolerance: SIMD[dtype, 1]](self) -> Int:
+    fn economize[error_tolerance: Scalar[dtype]](self) -> Int:
         """Economizes the Chebyshev series by minimizing the number of terms.
 
         Given a Chebyshev series `p` with `n` terms, this function returns the minimum
@@ -275,7 +275,7 @@ struct Chebyshev[
         asserting.assert_positive[dtype, "error_tolerance", error_tolerance]()
 
         var num_terms_required = num_terms
-        var error = SIMD[dtype, 1](0.0)
+        var error = Scalar[dtype](0.0)
 
         @parameter
         fn body_func[i: Int]() -> Bool:
@@ -335,7 +335,7 @@ struct Polynomial[
     var _coefficients: StaticTuple[num_terms, SIMD[dtype, simd_width]]
 
     @staticmethod
-    fn from_coefficients[*coefficients: SIMD[dtype, 1]]() -> Self:
+    fn from_coefficients[*coefficients: Scalar[dtype]]() -> Self:
         """Generates a Power series from a sequence of coefficients.
 
         Parameters:

--- a/specials/_internal/polynomial.mojo
+++ b/specials/_internal/polynomial.mojo
@@ -437,6 +437,11 @@ struct Polynomial[
         Returns:
             SIMD vector containing the values of the Power series at points `x`.
         """
+        # In terms of accuracy and execution time, there is no reason to use
+        # `math.polynomial_evaluate`. See the Jupyter notebooks below:
+        # - https://github.com/leandrolcampos/specials/blob/polynomial_evaluate/polyval_f32.ipynb
+        # - https://github.com/leandrolcampos/specials/blob/polynomial_evaluate/polyval_f64.ipynb
+
         var result = self.get[num_terms - 1]()
 
         @parameter
@@ -449,18 +454,3 @@ struct Polynomial[
             fori_loop[num_terms - 2, -1, -1, body_func]()
 
         return result
-
-
-fn _polynomial_evaluate[
-    num_terms: Int,
-    dtype: DType,
-    simd_width: Int,
-    polynomial: Polynomial[num_terms, dtype, simd_width],
-](x: SIMD[dtype, simd_width]) -> SIMD[dtype, simd_width]:
-    """Evaluates the Power series at `x` using the Mojo standard library procedure."""
-
-    # TODO: Evaluate the accuracy and computational performance of this function.
-
-    return math.polynomial_evaluate[
-        dtype, simd_width, num_terms, polynomial._coefficients
-    ](x)

--- a/specials/_internal/polynomial.mojo
+++ b/specials/_internal/polynomial.mojo
@@ -212,7 +212,7 @@ struct Chebyshev[
         if num_terms == 1:
             result = self.get[0]()
         elif num_terms == 2:
-            result = self.get[0]() + self.get[1]() * x
+            result = math.fma(self.get[1](), x, self.get[0]())
         else:
             let two_x = 2.0 * x
             var tmp = SIMD[dtype, simd_width](0.0)
@@ -227,7 +227,7 @@ struct Chebyshev[
 
             fori_loop[num_terms - 3, -1, -1, body_func]()
 
-            result = c0 + c1 * x
+            result = math.fma(c1, x, c0)
 
         return math.select(math.abs(x) > 1.0, nan, result)
 
@@ -437,7 +437,7 @@ struct Polynomial[
         Returns:
             SIMD vector containing the values of the Power series at points `x`.
         """
-        # In terms of accuracy and execution time, there is no reason to use
+        # In terms of accuracy or execution time, there is no reason to use
         # `math.polynomial_evaluate`. See the Jupyter notebooks below:
         # - https://github.com/leandrolcampos/specials/blob/polynomial_evaluate/polyval_f32.ipynb
         # - https://github.com/leandrolcampos/specials/blob/polynomial_evaluate/polyval_f64.ipynb

--- a/specials/_internal/polynomial_test.mojo
+++ b/specials/_internal/polynomial_test.mojo
@@ -25,6 +25,7 @@ fn test_chebyshev() raises:
 
     let p = P.Chebyshev[4, DType.float64, 1].from_coefficients[4.0, 3.0, 2.0, 1.0]()
 
+    unit_test.assert_equal(len(p), 4)
     unit_test.assert_equal(p.degree(), 3)
     unit_test.assert_equal(p.get[0](), 4.0)
     unit_test.assert_equal(p.get[1](), 3.0)
@@ -33,6 +34,7 @@ fn test_chebyshev() raises:
 
     let p_truncated = p.truncate[1]()
 
+    unit_test.assert_equal(len(p_truncated), 1)
     unit_test.assert_equal(p_truncated.degree(), 0)
     unit_test.assert_equal(p_truncated.get[0](), 4.0)
 
@@ -54,6 +56,7 @@ fn test_chebyshev_hex[dtype: DType]() raises:
             0x3FE00000_00000000,
         ]()
 
+    unit_test.assert_equal(len(p), 2)
     unit_test.assert_equal(p.degree(), 1)
     unit_test.assert_equal(p.get[0](), 1.0)
     unit_test.assert_equal(p.get[1](), 0.5)
@@ -86,6 +89,7 @@ fn test_polynomial() raises:
 
     let p = P.Polynomial[4, DType.float64, 1].from_coefficients[4.0, 3.0, 2.0, 1.0]()
 
+    unit_test.assert_equal(len(p), 4)
     unit_test.assert_equal(p.degree(), 3)
     unit_test.assert_equal(p.get[0](), 4.0)
     unit_test.assert_equal(p.get[1](), 3.0)
@@ -94,6 +98,7 @@ fn test_polynomial() raises:
 
     let p_truncated = p.truncate[1]()
 
+    unit_test.assert_equal(len(p_truncated), 1)
     unit_test.assert_equal(p_truncated.degree(), 0)
     unit_test.assert_equal(p_truncated.get[0](), 4.0)
 
@@ -115,6 +120,7 @@ fn test_polynomial_hex[dtype: DType]() raises:
             0x3FE00000_00000000,
         ]()
 
+    unit_test.assert_equal(len(p), 2)
     unit_test.assert_equal(p.degree(), 1)
     unit_test.assert_equal(p.get[0](), 1.0)
     unit_test.assert_equal(p.get[1](), 0.5)

--- a/specials/_internal/table.mojo
+++ b/specials/_internal/table.mojo
@@ -77,10 +77,10 @@ struct FloatTable[
         `uint64` if `dtype` is `float64`.
     """
 
-    var _data: StaticTuple[size, SIMD[dtype, 1]]
+    var _data: StaticTuple[size, Scalar[dtype]]
 
     @staticmethod
-    fn from_values[*values: SIMD[dtype, 1]]() -> Self:
+    fn from_values[*values: Scalar[dtype]]() -> Self:
         """Creates a table from a sequence of floating-point values.
 
         Parameters:
@@ -99,7 +99,7 @@ struct FloatTable[
             "The number of values must be equal to the parameter `size`.",
         ]()
 
-        var data = StaticTuple[size, SIMD[dtype, 1]]()
+        var data = StaticTuple[size, Scalar[dtype]]()
 
         for i in range(size):
             data[i] = values[i]
@@ -126,7 +126,7 @@ struct FloatTable[
             "The number of hexadecimal values must be equal to the parameter `size`.",
         ]()
 
-        var data = StaticTuple[size, SIMD[dtype, 1]]()
+        var data = StaticTuple[size, Scalar[dtype]]()
 
         for i in range(size):
             data[i] = bitcast[dtype](values[i])
@@ -145,7 +145,7 @@ struct FloatTable[
         return size
 
     @always_inline
-    fn get[index: Int](self: Self) -> SIMD[dtype, 1]:
+    fn get[index: Int](self: Self) -> Scalar[dtype]:
         """Returns the floating-point value of the table at the given index.
 
         Parameters:

--- a/specials/_internal/table.mojo
+++ b/specials/_internal/table.mojo
@@ -78,12 +78,7 @@ struct FloatTable[size: Int, dtype: DType](Sized):
             "The number of values must be equal to the parameter `size`.",
         ]()
 
-        var data = StaticTuple[size, Scalar[dtype]]()
-
-        for i in range(size):
-            data[i] = values[i]
-
-        return Self {_data: data}
+        return Self {_data: StaticTuple[size, Scalar[dtype]](values)}
 
     @staticmethod
     fn from_hexadecimal_values[

--- a/specials/_internal/table_test.mojo
+++ b/specials/_internal/table_test.mojo
@@ -20,6 +20,16 @@ from specials._internal.table import FloatTable
 from specials._internal.testing import UnitTest
 
 
+fn test_sized() raises:
+    let unit_test = UnitTest("test_sized")
+
+    let table = FloatTable[4, DType.float32].from_values[1.0, 2.0, 3.0, 4.0]()
+    let expected = 4
+    let actual = len(table)
+
+    unit_test.assert_equal(actual, expected)
+
+
 fn test_unsafe_lookup[dtype: DType]() raises:
     let unit_test = UnitTest("test_unsafe_lookup_" + str(dtype))
 
@@ -78,6 +88,8 @@ fn test_hexadecimal_values[dtype: DType]() raises:
 
 
 fn main() raises:
+    test_sized()
+
     test_unsafe_lookup[DType.float32]()
     test_unsafe_lookup[DType.float64]()
 

--- a/specials/_internal/tensor.mojo
+++ b/specials/_internal/tensor.mojo
@@ -116,7 +116,7 @@ fn _elementwise_impl[
     dtype: DType,
     simd_width: Int,
     force_sequential: Bool,
-](x: Tensor[dtype], scalar: SIMD[dtype, 1], inout result: Tensor[dtype]) -> None:
+](x: Tensor[dtype], scalar: Scalar[dtype], inout result: Tensor[dtype]) -> None:
     """Implements the elementwise operation on a tensor and a scalar."""
     let num_elements = x.num_elements()
     var remaining_elements = num_elements
@@ -296,7 +296,7 @@ fn elementwise[
     dtype: DType,
     simd_width: Int = simdwidthof[dtype](),
     force_sequential: Bool = False,
-](x: Tensor[dtype], scalar: SIMD[dtype, 1]) -> Tensor[dtype]:
+](x: Tensor[dtype], scalar: Scalar[dtype]) -> Tensor[dtype]:
     """Applies a binary operator to a tensor and a scalar element-wise.
 
     Parameters:
@@ -423,7 +423,7 @@ fn run_benchmark[
     force_sequential: Bool = False,
 ](
     x: Tensor[dtype],
-    scalar: SIMD[dtype, 1],
+    scalar: Scalar[dtype],
     num_warmup: Int = 2,
     max_iters: Int = 100_000,
     min_runtime_secs: SIMD[DType.float64, 1] = 0.5,
@@ -539,8 +539,8 @@ fn run_benchmark[
 fn random_uniform[
     dtype: DType, simd_width: Int = simdwidthof[dtype]()
 ](
-    min_value: SIMD[dtype, 1],
-    max_value: SIMD[dtype, 1],
+    min_value: Scalar[dtype],
+    max_value: Scalar[dtype],
     *shape: Int,
 ) raises -> Tensor[
     dtype

--- a/specials/_internal/tensor.mojo
+++ b/specials/_internal/tensor.mojo
@@ -73,7 +73,9 @@ fn _elementwise_impl[
             and num_worker >= 2
         ):
             let num_elements_per_work_item = num_simds_per_work_item * simd_width
-            remaining_elements -= num_simds_per_work_item * num_work_items * simd_width
+            remaining_elements = math.fma(
+                -num_elements_per_work_item, num_work_items, remaining_elements
+            )
 
             @parameter
             fn execute_work_item(work_item_id: Int):
@@ -141,7 +143,9 @@ fn _elementwise_impl[
             and num_worker >= 2
         ):
             let num_elements_per_work_item = num_simds_per_work_item * simd_width
-            remaining_elements -= num_simds_per_work_item * num_work_items * simd_width
+            remaining_elements = math.fma(
+                -num_elements_per_work_item, num_work_items, remaining_elements
+            )
 
             @parameter
             fn execute_work_item(work_item_id: Int):
@@ -215,7 +219,9 @@ fn _elementwise_impl[
             and num_worker >= 2
         ):
             let num_elements_per_work_item = num_simds_per_work_item * simd_width
-            remaining_elements -= num_simds_per_work_item * num_work_items * simd_width
+            remaining_elements = math.fma(
+                -num_elements_per_work_item, num_work_items, remaining_elements
+            )
 
             @parameter
             fn execute_work_item(work_item_id: Int):

--- a/specials/_internal/tensor_test.mojo
+++ b/specials/_internal/tensor_test.mojo
@@ -34,7 +34,7 @@ fn test_elemwise_tensor[
     let unit_test = UnitTest(
         "test_elemwise_tensor_" + str(x.spec()) + "_" + str(force_sequential)
     )
-    let rtol: SIMD[dtype, 1]
+    let rtol: Scalar[dtype]
 
     @parameter
     if dtype == DType.float32:
@@ -53,13 +53,13 @@ fn test_elemwise_tensor_scalar[
     random.seed(42)
 
     let x = random.rand[dtype](shape)
-    let y = SIMD[dtype, 1](1.5)
+    let y = Scalar[dtype](1.5)
     let res = elementwise[math.add, force_sequential=force_sequential](x, y)
 
     let unit_test = UnitTest(
         "test_elemwise_tensor_scalar_" + str(x.spec()) + "_" + str(force_sequential)
     )
-    let rtol: SIMD[dtype, 1]
+    let rtol: Scalar[dtype]
 
     @parameter
     if dtype == DType.float32:
@@ -84,7 +84,7 @@ fn test_elemwise_tensor_tensor[
     let unit_test = UnitTest(
         "test_elemwise_tensor_tensor_" + str(x.spec()) + "_" + str(force_sequential)
     )
-    let rtol: SIMD[dtype, 1]
+    let rtol: Scalar[dtype]
 
     @parameter
     if dtype == DType.float32:

--- a/specials/_internal/testing.mojo
+++ b/specials/_internal/testing.mojo
@@ -122,8 +122,8 @@ struct UnitTest[raise_error: Bool = False]:
         self,
         actual: SIMD[dtype, simd_width],
         desired: SIMD[dtype, simd_width],
-        absolute_tolerance: SIMD[dtype, 1],
-        relative_tolerance: SIMD[dtype, 1],
+        absolute_tolerance: Scalar[dtype],
+        relative_tolerance: Scalar[dtype],
     ) raises:
         """Asserts that the input values are equal up to a tolerance. If it is not then
         an `Error` is raised.

--- a/specials/elementary/exp_test.mojo
+++ b/specials/elementary/exp_test.mojo
@@ -27,7 +27,7 @@ from specials.elementary.exp import exp
 from specials.elementary.log import log
 
 
-fn _mp_exp[dtype: DType](x: SIMD[dtype, 1]) raises -> SIMD[dtype, 1]:
+fn _mp_exp[dtype: DType](x: Scalar[dtype]) raises -> Scalar[dtype]:
     let mp = Python.import_module("mpmath")
     let result = mp.exp(mp.mpf(x))
     return result.to_float64().cast[dtype]()
@@ -45,9 +45,9 @@ fn test_exp[dtype: DType]() raises:
     else:
         pass
 
-    let xs = StaticTuple[5, SIMD[dtype, 1]](xmin, 0.0, 0.5 * xeps, 1.0, xmax)
+    let xs = StaticTuple[5, Scalar[dtype]](xmin, 0.0, 0.5 * xeps, 1.0, xmax)
 
-    let rtol: SIMD[dtype, 1]
+    let rtol: Scalar[dtype]
 
     @parameter
     if dtype == DType.float32:

--- a/specials/elementary/expm1.mojo
+++ b/specials/elementary/expm1.mojo
@@ -32,14 +32,12 @@ from specials._internal.table import FloatTable, get_hexadecimal_dtype
 
 
 @always_inline
-fn _get_s_lead[
-    dtype: DType, hexadecimal_dtype: DType = get_hexadecimal_dtype[dtype]()
-]() -> FloatTable[32, dtype, hexadecimal_dtype]:
+fn _get_s_lead[dtype: DType]() -> FloatTable[32, dtype]:
     """Returns the table entries of `s_lead` for single or double precision."""
 
     @parameter
     if dtype == DType.float32:
-        return FloatTable[32, dtype, hexadecimal_dtype].from_hexadecimal_values[
+        return FloatTable[32, dtype].from_hexadecimal_values[
             0x3F80_0000,
             0x3F82_CD80,
             0x3F85_AAC0,
@@ -74,7 +72,7 @@ fn _get_s_lead[
             0x3FFA_8380,
         ]()
     else:  # dtype == DType.float64
-        return FloatTable[32, dtype, hexadecimal_dtype].from_hexadecimal_values[
+        return FloatTable[32, dtype].from_hexadecimal_values[
             0x3FF00000_00000000,
             0x3FF059B0_D3158540,
             0x3FF0B558_6CF98900,
@@ -111,14 +109,12 @@ fn _get_s_lead[
 
 
 @always_inline
-fn _get_s_trail[
-    dtype: DType, hexadecimal_dtype: DType = get_hexadecimal_dtype[dtype]()
-]() -> FloatTable[32, dtype, hexadecimal_dtype]:
+fn _get_s_trail[dtype: DType]() -> FloatTable[32, dtype]:
     """Returns the table entries of `s_trail` for single or double precision."""
 
     @parameter
     if dtype == DType.float32:
-        return FloatTable[32, dtype, hexadecimal_dtype].from_hexadecimal_values[
+        return FloatTable[32, dtype].from_hexadecimal_values[
             0x0000_0000,
             0x3553_1585,
             0x34D9_F312,
@@ -153,7 +149,7 @@ fn _get_s_trail[
             0x36CB_6DC9,
         ]()
     else:  # dtype == DType.float64
-        return FloatTable[32, dtype, hexadecimal_dtype].from_hexadecimal_values[
+        return FloatTable[32, dtype].from_hexadecimal_values[
             0x00000000_00000000,
             0x3D0A1D73_E2A475B4,
             0x3CEEC531_7256E308,
@@ -190,11 +186,11 @@ fn _get_s_trail[
 
 
 @register_passable("trivial")
-struct _STable[dtype: DType, hexadecimal_dtype: DType = get_hexadecimal_dtype[dtype]()]:
+struct _STable[dtype: DType]:
     """Table entries of `s_lead` and `s_trail` for single or double precision."""
 
-    alias lead = _get_s_lead[dtype, hexadecimal_dtype]()
-    alias trail = _get_s_trail[dtype, hexadecimal_dtype]()
+    alias lead = _get_s_lead[dtype]()
+    alias trail = _get_s_trail[dtype]()
 
 
 fn _expm1_procedure_1[

--- a/specials/elementary/expm1.mojo
+++ b/specials/elementary/expm1.mojo
@@ -333,7 +333,7 @@ fn _expm1_procedure_2[
 
     @parameter
     if dtype == DType.float32:
-        alias exp2 = math.ldexp(SIMD[dtype, 1](1.0), 16)
+        alias exp2 = math.ldexp(Scalar[dtype](1.0), 16)
         x_exp2 = safe_x * exp2
 
         alias g = Polynomial[5, dtype, simd_width].from_hexadecimal_coefficients[
@@ -346,7 +346,7 @@ fn _expm1_procedure_2[
         x3_gval = safe_x * safe_x * safe_x * g(safe_x)
 
     else:  # dtype == DType.float64
-        alias exp2 = math.ldexp(SIMD[dtype, 1](1.0), 30)
+        alias exp2 = math.ldexp(Scalar[dtype](1.0), 30)
         x_exp2 = safe_x * exp2
 
         alias g = Polynomial[9, dtype, simd_width].from_hexadecimal_coefficients[

--- a/specials/elementary/expm1_test.mojo
+++ b/specials/elementary/expm1_test.mojo
@@ -29,7 +29,7 @@ from specials.elementary.expm1 import expm1
 from specials.elementary.log import log
 
 
-fn _mp_expm1[dtype: DType](x: SIMD[dtype, 1]) raises -> SIMD[dtype, 1]:
+fn _mp_expm1[dtype: DType](x: Scalar[dtype]) raises -> Scalar[dtype]:
     let mp = Python.import_module("mpmath")
     let result = mp.expm1(mp.mpf(x))
     return result.to_float64().cast[dtype]()
@@ -39,9 +39,9 @@ fn test_expm1[dtype: DType]() raises:
     let unit_test = UnitTest("test_expm1_" + str(dtype))
 
     let xeps = FloatLimits[dtype].eps
-    let xs = StaticTuple[5, SIMD[dtype, 1]](0.1 * xeps, 0.01, 0.1, 1.0, 10.0)
+    let xs = StaticTuple[5, Scalar[dtype]](0.1 * xeps, 0.01, 0.1, 1.0, 10.0)
 
-    let rtol: SIMD[dtype, 1]
+    let rtol: Scalar[dtype]
 
     @parameter
     if dtype == DType.float32:
@@ -60,11 +60,11 @@ fn test_expm1[dtype: DType]() raises:
 fn test_expm1_special_cases[dtype: DType]() raises:
     let unit_test = UnitTest("test_expm1_special_cases_" + str(dtype))
 
-    let xeps: SIMD[dtype, 1]
-    let xsml_inf: SIMD[dtype, 1]
-    let xsml_sup: SIMD[dtype, 1]
-    let xmin: SIMD[dtype, 1]
-    let xmax: SIMD[dtype, 1]
+    let xeps: Scalar[dtype]
+    let xsml_inf: Scalar[dtype]
+    let xsml_sup: Scalar[dtype]
+    let xmin: Scalar[dtype]
+    let xmax: Scalar[dtype]
     let nan = math.nan[dtype]()
     let inf = math.limit.inf[dtype]()
 
@@ -82,7 +82,7 @@ fn test_expm1_special_cases[dtype: DType]() raises:
         xmin = bitcast[dtype, DType.uint64](0xC042B708_872320E1)
         xmax = log(FloatLimits[dtype].max)
 
-    let xs = StaticTuple[12, SIMD[dtype, 1]](
+    let xs = StaticTuple[12, Scalar[dtype]](
         nan,
         -inf,
         2.0 * xmin,
@@ -97,7 +97,7 @@ fn test_expm1_special_cases[dtype: DType]() raises:
         inf,
     )
 
-    let rtol: SIMD[dtype, 1]
+    let rtol: Scalar[dtype]
 
     @parameter
     if dtype == DType.float32:
@@ -108,7 +108,7 @@ fn test_expm1_special_cases[dtype: DType]() raises:
     for i in range(len(xs)):
         let x = xs[i]
         let actual = expm1(x)
-        let expected: SIMD[dtype, 1]
+        let expected: Scalar[dtype]
 
         if math.isnan(x):
             expected = nan

--- a/specials/elementary/log_test.mojo
+++ b/specials/elementary/log_test.mojo
@@ -26,7 +26,7 @@ from specials._internal.testing import UnitTest
 from specials.elementary.log import log
 
 
-fn _mp_log[dtype: DType](x: SIMD[dtype, 1]) raises -> SIMD[dtype, 1]:
+fn _mp_log[dtype: DType](x: Scalar[dtype]) raises -> Scalar[dtype]:
     let mp = Python.import_module("mpmath")
     let result = mp.log(mp.mpf(x))
     return result.to_float64().cast[dtype]()
@@ -40,11 +40,11 @@ fn test_log[dtype: DType]() raises:
     let eps = FloatLimits[dtype].eps
     let xmax = FloatLimits[dtype].max
 
-    let xs = StaticTuple[7, SIMD[dtype, 1]](
+    let xs = StaticTuple[7, Scalar[dtype]](
         xmin, epsneg, eps, 1.0 - epsneg, 1.0, 1.0 + eps, xmax
     )
 
-    let rtol: SIMD[dtype, 1]
+    let rtol: Scalar[dtype]
 
     @parameter
     if dtype == DType.float32:

--- a/specials/gamma.mojo
+++ b/specials/gamma.mojo
@@ -22,7 +22,7 @@
 # References:
 #
 # Didonato, A. R., & Morris Jr, A. H. (1992). Algorithm 708: Significant digit
-# computation of the incomplete beta function ratios.
+#   computation of the incomplete beta function ratios.
 # ACM Transactions on Mathematical Software (TOMS), 18(3), 360-373.
 # https://dl.acm.org/doi/abs/10.1145/131766.131776
 

--- a/specials/gamma_test.mojo
+++ b/specials/gamma_test.mojo
@@ -43,7 +43,7 @@ fn test_lgamma_correction[dtype: DType]() raises:
     )
     let actual = specials.lgamma_correction(x)
 
-    let rtol: SIMD[dtype, 1]
+    let rtol: Scalar[dtype]
 
     @parameter
     if dtype == DType.float32:
@@ -59,7 +59,7 @@ fn test_lgamma_correction_special_cases[dtype: DType]() raises:
 
     let inf = math.limit.inf[dtype]()
     let nan = math.nan[dtype]()
-    let zero = SIMD[dtype, 1](0.0)
+    let zero = Scalar[dtype](0.0)
     let x = SIMD[dtype, 4](nan, -inf, zero, inf)
 
     let expected = SIMD[dtype, 4](nan, nan, nan, zero)
@@ -87,7 +87,7 @@ fn test_lgamma1p_region1[dtype: DType]() raises:
         -1.12591780722776981673572240680e-1,
     )
 
-    let rtol: SIMD[dtype, 1]
+    let rtol: Scalar[dtype]
 
     @parameter
     if dtype == DType.float32:
@@ -112,7 +112,7 @@ fn test_lgamma1p_region2[dtype: DType]() raises:
         1.248717148923965943024412876132e-1,
     )
 
-    let rtol: SIMD[dtype, 1]
+    let rtol: Scalar[dtype]
 
     @parameter
     if dtype == DType.float32:
@@ -184,7 +184,7 @@ fn test_lbeta_edge_cases() raises:
     unit_test.assert_true(result, "Some of the results are incorrect.")
 
 
-fn _mp_rgamma1pm1[dtype: DType](x: SIMD[dtype, 1]) raises -> SIMD[dtype, 1]:
+fn _mp_rgamma1pm1[dtype: DType](x: Scalar[dtype]) raises -> Scalar[dtype]:
     let mp = Python.import_module("mpmath")
     mp.mp.dps += 300
 
@@ -201,11 +201,11 @@ fn test_rgamma1pm1[dtype: DType]() raises:
     let epsneg = FloatLimits[dtype].epsneg
     let eps = FloatLimits[dtype].eps
 
-    let xs = StaticTuple[10, SIMD[dtype, 1]](
+    let xs = StaticTuple[10, Scalar[dtype]](
         -1.0 + epsneg, -0.5, -tiny, 0.0, tiny, 0.5, 1.0 - epsneg, 1.0, 1.5 - eps, 7.0
     )
 
-    let rtol: SIMD[dtype, 1]
+    let rtol: Scalar[dtype]
 
     @parameter
     if dtype == DType.float32:


### PR DESCRIPTION
Some of the improvements added were based on @soraros' feedback:
- Replace `SIMD[dtype, 1]` with `Scalar[dtype]`
- Always infer parameter `hexadecimal_dtype`
- Avoid a loop in the `from_values` method of the `FloatTable` struct
- Use automatic parameterization in the lookup procedures of the `FloatTable` struct