### PR TITLE
Simplify and Optimize `BigInt` operations

### DIFF
--- a/src/specials/utils/big_int.mojo
+++ b/src/specials/utils/big_int.mojo
@@ -294,7 +294,7 @@ fn _compare(lhs: SIMD, rhs: __type_of(lhs)) -> SIMD[DType.int8, lhs.size]:
 
 @always_inline
 fn _compare(lhs: BigInt, rhs: __type_of(lhs)) -> SIMD[DType.int8, lhs.size]:
-    """Compares two `BigInt` values element-wise."""
+    """Compares two `BigInt` vectors element-wise."""
     alias ONE = SIMD[DType.int8, lhs.size](1)
 
     var result = SIMD[DType.int8, lhs.size](0)

--- a/src/specials/utils/big_int.mojo
+++ b/src/specials/utils/big_int.mojo
@@ -530,16 +530,6 @@ struct BigInt[
 
     @staticmethod
     @always_inline
-    fn all_ones() -> Self:
-        """Creates a `BigInt` vector with all bits set to one.
-
-        Returns:
-            A new `BigInt` vector with all bits set to one.
-        """
-        return ~Self()
-
-    @staticmethod
-    @always_inline
     fn max() -> Self:
         """Creates a `BigInt` vector with all elements set to the maximum
         representable value.
@@ -548,7 +538,7 @@ struct BigInt[
             A new `BigInt` vector with all elements set to the maximum
             representable value.
         """
-        var result = Self.all_ones()
+        var result = ~Self()
 
         @parameter
         if signed:
@@ -573,26 +563,6 @@ struct BigInt[
             result.set_most_significant_bit()
 
         return result
-
-    @staticmethod
-    @always_inline
-    fn one() -> Self:
-        """Creates a `BigInt` vector with all elements set to one.
-
-        Returns:
-            A new `BigInt` vector with all elements set to one.
-        """
-        return Self(1)
-
-    @staticmethod
-    @always_inline
-    fn zero() -> Self:
-        """Creates a `BigInt` vector with all elements set to zero.
-
-        Returns:
-            A new `BigInt` vector with all elements set to zero.
-        """
-        return Self()
 
     # ===------------------------------------------------------------------=== #
     # Operator dunders

--- a/src/specials/utils/big_int.mojo
+++ b/src/specials/utils/big_int.mojo
@@ -212,71 +212,69 @@ fn _iota[type: DType, size: Int]() -> SIMD[type, size]:
 
 @always_inline
 fn _shift[
-    type: DType, size: Int, *, is_left_shift: Bool
-](
-    *,
-    val: InlineArray[SIMD[type, size], _],
-    offset: SIMD[type, size],
-    is_negative: SIMD[DType.bool, size],
-    inout dst: __type_of(val),
-):
+    *, is_left_shift: Bool
+](val: BigInt, offset: SIMD[DType.index, val.size],) -> __type_of(val):
     """Performs a bitwise shift on the internal representation of a `BigInt`."""
-    constrained[type.is_unsigned(), "type must be an unsigned, integral type"]()
+    alias SHIFT = _iota[DType.index, val.size]()
+    alias TYPE_BITWIDTH = val.word_type.bitwidth()
 
-    alias TYPE_BITWIDTH = type.bitwidth()
-
-    var val_ptr = DTypePointer(val.unsafe_ptr().bitcast[Scalar[type]]())
+    var dst = __type_of(val)(unsafe_uninitialized=True)
+    var val_ptr = DTypePointer(
+        val._storage.unsafe_ptr().bitcast[Scalar[val.word_type]]()
+    )
 
     if all(offset == 0):
 
         @parameter
-        for i in range(dst.size):
-            dst[i] = val[i]
+        for i in range(val.WORD_COUNT):
+            dst._storage[i] = val._storage[i]
 
-        return
+        return dst
 
     @always_inline
     @parameter
     fn at(index: SIMD[DType.index, _]) -> __type_of(index):
         @parameter
         if is_left_shift:
-            return dst.size - index - 1
+            return val.WORD_COUNT - index - 1
         else:
             return index
 
     @always_inline
     @parameter
-    fn safe_gather(index: SIMD[DType.index, size]) -> SIMD[type, size]:
-        alias SHIFT = _iota[DType.index, size]()
-
-        var is_index_below_size = index < dst.size
+    fn safe_gather(
+        index: SIMD[DType.index, val.size]
+    ) -> SIMD[val.word_type, val.size]:
+        var is_index_below_size = index < val.WORD_COUNT
         var mask = (index >= 0) & is_index_below_size
-        var default = (is_negative & ~is_index_below_size).select(
-            SIMD[type, size](-1), 0
+        var default = (val.is_negative() & ~is_index_below_size).select(
+            SIMD[val.word_type, val.size](-1), 0
         )
 
-        return val_ptr.gather(index.fma(size, SHIFT), mask, default)
+        return val_ptr.gather(index.fma(val.size, SHIFT), mask, default)
 
-    var index_offset = offset.cast[DType.index]() // TYPE_BITWIDTH
-    var bit_offset = offset % TYPE_BITWIDTH
+    var index_offset = offset // TYPE_BITWIDTH
+    var bit_offset = (offset % TYPE_BITWIDTH).cast[val.word_type]()
 
     @parameter
-    for i in range(dst.size):
+    for i in range(val.WORD_COUNT):
         var index = Scalar[DType.index](i)
         var part1 = safe_gather(at(index + index_offset))
         var part2 = safe_gather(at(index + index_offset + 1))
 
         @parameter
         if is_left_shift:
-            dst[int(at(index))] = (bit_offset == 0).select(
+            dst._storage[int(at(index))] = (bit_offset == 0).select(
                 part1,
                 part1 << bit_offset | part2 >> (TYPE_BITWIDTH - bit_offset),
             )
         else:
-            dst[int(at(index))] = (bit_offset == 0).select(
+            dst._storage[int(at(index))] = (bit_offset == 0).select(
                 part1,
                 part1 >> bit_offset | part2 << (TYPE_BITWIDTH - bit_offset),
             )
+
+    return dst
 
 
 # ===----------------------------------------------------------------------=== #
@@ -698,7 +696,7 @@ struct BigInt[
         return result
 
     @always_inline
-    fn __lshift__(self, offset: SIMD[word_type, size]) -> Self:
+    fn __lshift__(self, offset: SIMD[DType.index, size]) -> Self:
         """Performs a bitwise left shift on a `BigInt` vector, element-wise.
 
         Args:
@@ -714,19 +712,10 @@ struct BigInt[
             "offset must be within bounds",
         )
 
-        var result = Self(unsafe_uninitialized=True)
-
-        _shift[is_left_shift=True](
-            val=self._storage,
-            offset=offset,
-            is_negative=self.is_negative(),
-            dst=result._storage,
-        )
-
-        return result
+        return _shift[is_left_shift=True](self, offset)
 
     @always_inline
-    fn __ilshift__(inout self, offset: SIMD[word_type, size]):
+    fn __ilshift__(inout self, offset: SIMD[DType.index, size]):
         """Performs an in-place bitwise left shift on a `BigInt` vector,
         element-wise.
 
@@ -737,7 +726,7 @@ struct BigInt[
         self = self << offset
 
     @always_inline
-    fn __rshift__(self, offset: SIMD[word_type, size]) -> Self:
+    fn __rshift__(self, offset: SIMD[DType.index, size]) -> Self:
         """Performs a bitwise right shift on a `BigInt` vector, element-wise.
 
         Args:
@@ -753,19 +742,10 @@ struct BigInt[
             "offset must be within bounds",
         )
 
-        var result = Self(unsafe_uninitialized=True)
-
-        _shift[is_left_shift=False](
-            val=self._storage,
-            offset=offset,
-            is_negative=self.is_negative(),
-            dst=result._storage,
-        )
-
-        return result
+        return _shift[is_left_shift=False](self, offset)
 
     @always_inline
-    fn __irshift__(inout self, offset: SIMD[word_type, size]):
+    fn __irshift__(inout self, offset: SIMD[DType.index, size]):
         """Performs an in-place bitwise right shift on a `BigInt` vector,
         element-wise.
 

--- a/src/specials/utils/big_int.mojo
+++ b/src/specials/utils/big_int.mojo
@@ -255,6 +255,7 @@ fn _shift[
 
         return
 
+    @always_inline
     @parameter
     fn at(index: SIMD[DType.index, _]) -> __type_of(index):
         @parameter
@@ -263,6 +264,7 @@ fn _shift[
         else:
             return index
 
+    @always_inline
     @parameter
     fn safe_get(index: SIMD[DType.index, size]) -> SIMD[type, size]:
         var is_index_below_size = index < dst.size

--- a/test/utils/test_big_int.mojo
+++ b/test/utils/test_big_int.mojo
@@ -315,7 +315,7 @@ fn test_invert() raises:
 fn test_lshift() raises:
     var sval8 = BigInt[8, size=4, word_type = DType.uint8](-99)
     var uval8 = BigUInt[8, size=4, word_type = DType.uint8](157)
-    var offset = SIMD[DType.uint8, 4](0, 1, 4, 7)
+    var offset = SIMD[DType.index, 4](0, 1, 4, 7)
 
     _assert_equal(sval8 << 0, -99)
     _assert_equal(sval8 << offset, SIMD[DEST_TYPE, 4](-99, 58, -48, -128))
@@ -325,7 +325,7 @@ fn test_lshift() raises:
 
     var sval24 = BigInt[24, size=4, word_type = DType.uint8](-3_962_546)
     var uval24 = BigUInt[24, size=4, word_type = DType.uint8](12_814_670)
-    offset = SIMD[uval24.word_type, 4](0, 1, 12, 23)
+    offset = SIMD[DType.index, 4](0, 1, 12, 23)
 
     _assert_equal(sval24 << 0, -3_962_546)
     _assert_equal(
@@ -351,7 +351,7 @@ fn test_rshift() raises:
         SIMD[DType.int8, 4](1, 99, -99, -1)
     )
     var uval8 = BigUInt[8, size=4, word_type = DType.uint8](157)
-    var offset = SIMD[DType.uint8, 4](0, 1, 4, 7)
+    var offset = SIMD[DType.index, 4](0, 1, 4, 7)
 
     _assert_equal(sval8 >> 0, SIMD[DEST_TYPE, 4](1, 99, -99, -1))
     _assert_equal(sval8 >> offset, SIMD[DEST_TYPE, 4](1, 49, -7, -1))
@@ -361,7 +361,7 @@ fn test_rshift() raises:
 
     var sval24 = BigInt[24, size=4, word_type = DType.uint8](-3_962_546)
     var uval24 = BigUInt[24, size=4, word_type = DType.uint8](12_814_670)
-    offset = SIMD[uval24.word_type, 4](0, 1, 12, 23)
+    offset = SIMD[DType.index, 4](0, 1, 12, 23)
 
     _assert_equal(sval24 >> 0, -3_962_546)
     _assert_equal(

--- a/test/utils/test_big_int.mojo
+++ b/test/utils/test_big_int.mojo
@@ -139,14 +139,6 @@ fn test_explicit_copy() raises:
             _assert_equal(copy, 2)
 
 
-fn test_all_ones() raises:
-    _assert_equal(BigInt[8, size=1].all_ones(), -1)
-    _assert_equal(BigInt[24, size=1].all_ones(), -1)
-
-    _assert_equal(BigUInt[8, size=1].all_ones(), 255)
-    _assert_equal(BigUInt[24, size=1].all_ones(), 16_777_215)
-
-
 fn test_min() raises:
     _assert_equal(BigInt[8, size=1].min(), -128)
     _assert_equal(BigInt[24, size=1].min(), -8_388_608)
@@ -161,22 +153,6 @@ fn test_max() raises:
 
     _assert_equal(BigUInt[8, size=1].max(), 255)
     _assert_equal(BigUInt[24, size=1].max(), 16_777_215)
-
-
-fn test_one() raises:
-    _assert_equal(BigInt[8, size=1].one(), 1)
-    _assert_equal(BigInt[24, size=1].one(), 1)
-
-    _assert_equal(BigUInt[8, size=1].one(), 1)
-    _assert_equal(BigUInt[24, size=1].one(), 1)
-
-
-fn test_zero() raises:
-    _assert_equal(BigInt[8, size=1].zero(), 0)
-    _assert_equal(BigInt[24, size=1].zero(), 0)
-
-    _assert_equal(BigUInt[8, size=1].zero(), 0)
-    _assert_equal(BigUInt[24, size=1].zero(), 0)
 
 
 fn test_add() raises:
@@ -591,11 +567,8 @@ fn main() raises:
     test_init_from_unsigned_simd()
     test_explicit_copy()
 
-    test_all_ones()
     test_min()
     test_max()
-    test_one()
-    test_zero()
 
     test_add()
     test_iadd()


### PR DESCRIPTION
This PR introduces several refinements and optimizations to the `BigInt` module, improving both the performance and clarity of the codebase:

1. **Removed Trivial Methods**: 
   - Deleted the `all_ones()`, `one()`, and `zero()` methods as they were deemed trivial and unnecessary, simplifying the codebase.

2. **Inlined Nested Functions**:
   - Inlined nested functions such as `at` and `safe_get` in the `_shift` function by adding `@always_inline` decorators, improving performance by reducing function call overhead.

3. **Updated Documentation**:
   - Updated docstrings to replace references to "values" with "vectors" in the context of `BigInt` comparisons to enhance clarity and maintain consistency.

4. **Specialized `_shift` Function**:
   - Refined the `_shift` function interface by specializing it for `BigInt` and changing the `offset` parameter type from `word_type` to `DType.index`. This adjustment ensures compatibility with all valid shift values and enhances the robustness of shift operations.

These changes collectively improve the readability, maintainability, and efficiency of the `BigInt` module, aligning with best practices for performance optimization and clear documentation.