### PR TITLE
Support for `BigInt` initialization with IntLiteral values

### DIFF
--- a/src/specials/utils/big_int.mojo
+++ b/src/specials/utils/big_int.mojo
@@ -23,7 +23,7 @@
 
 from bit import countl_zero
 from memory import DTypePointer, memset_zero
-from sys.info import is_64bit
+from sys.info import is_64bit, sizeof
 from sys.intrinsics import _RegisterPackType
 from utils import InlineArray
 from utils.numerics import max_finite
@@ -364,6 +364,20 @@ fn _big_int_construction_checks[
     ]()
 
 
+@always_inline
+fn _is_casting_safe[bits: Int, signed: Bool](value: IntLiteral) -> Bool:
+    """Checks if `value` fits in an integer with the specified number of bits
+    and signedness.
+    """
+    constrained[bits > 0, "number of bits must be positive"]()
+
+    @parameter
+    if signed:
+        return bits >= value._bit_width()
+    else:
+        return value >= 0 and bits >= (value._bit_width() - 1)
+
+
 alias BigUInt = BigInt[_, size=_, signed=False, word_type=_]
 """Represents a small vector of arbitrary, fixed bit-size unsigned integers."""
 
@@ -401,7 +415,7 @@ struct BigInt[
     # Aliases
     # ===------------------------------------------------------------------=== #
 
-    alias WORD_TYPE_BITWIDTH = word_type.bitwidth()
+    alias WORD_TYPE_BITWIDTH = 8 * sizeof[word_type]()
     """The size, in bits, of the `word_type` parameter."""
 
     alias WORD_COUNT = bits // Self.WORD_TYPE_BITWIDTH
@@ -447,6 +461,29 @@ struct BigInt[
 
         _ = unsafe_uninitialized
         self._storage = Self.StorageType(unsafe_uninitialized=True)
+
+    @always_inline
+    fn __init__(inout self, value: IntLiteral):
+        """Initializes the `BigInt` vector with a signed integer literal.
+
+        Args:
+            value: The signed integer literal to be splatted across all the
+                elements of the `BigInt` vector.
+        """
+        _big_int_construction_checks[bits, word_type]()
+
+        debug_assert(
+            _is_casting_safe[bits, signed](value),
+            "value must be within the bounds of the `BigInt`",
+        )
+
+        self._storage = Self.StorageType(unsafe_uninitialized=True)
+        var tmp: IntLiteral = value
+
+        @parameter
+        for i in range(Self.WORD_COUNT):
+            self._storage[i] = SIMD[word_type, size](tmp)
+            tmp >>= Self.WORD_TYPE_BITWIDTH
 
     @always_inline
     fn __init__(inout self, value: Int):

--- a/src/specials/utils/big_int.mojo
+++ b/src/specials/utils/big_int.mojo
@@ -285,16 +285,14 @@ fn _shift[
 @always_inline
 fn _compare(lhs: SIMD, rhs: __type_of(lhs)) -> SIMD[DType.int8, lhs.size]:
     """Compares two SIMD vectors element-wise."""
-    alias ONE = SIMD[DType.int8, lhs.size](1)
-
-    return (lhs == rhs).select(0, (lhs < rhs).select(-1, ONE))
+    return (lhs == rhs).select(
+        0, (lhs < rhs).select(-1, SIMD[DType.int8, lhs.size](1))
+    )
 
 
 @always_inline
 fn _compare(lhs: BigInt, rhs: __type_of(lhs)) -> SIMD[DType.int8, lhs.size]:
     """Compares two `BigInt` vectors element-wise."""
-    alias ONE = SIMD[DType.int8, lhs.size](1)
-
     var result = SIMD[DType.int8, lhs.size](0)
 
     @parameter
@@ -302,7 +300,7 @@ fn _compare(lhs: BigInt, rhs: __type_of(lhs)) -> SIMD[DType.int8, lhs.size]:
         var lhs_is_negative = lhs.is_negative()
         var rhs_is_negative = rhs.is_negative()
         result = (lhs_is_negative != rhs_is_negative).select(
-            lhs_is_negative.select(-1, ONE), result
+            lhs_is_negative.select(-1, SIMD[DType.int8, lhs.size](1)), result
         )
 
     @parameter

--- a/test/utils/test_big_int.mojo
+++ b/test/utils/test_big_int.mojo
@@ -63,12 +63,28 @@ fn test_init_unsafe() raises:
     _ = BigUInt[24, size=1](unsafe_uninitialized=True)
 
 
-fn test_init_from_int() raises:
-    _assert_equal(BigInt[8, size=1](1), 1)
-    _assert_equal(BigInt[24, size=1](1), 1)
+fn test_init_from_int_literal() raises:
+    _assert_equal(BigInt[8, size=1](0), 0)
+    _assert_equal(BigInt[8, size=1](127), 127)
+    _assert_equal(BigInt[8, size=1](-1), -1)
+    _assert_equal(BigInt[8, size=1](-128), -128)
+    _assert_equal(BigInt[24, size=1](0), 0)
+    _assert_equal(BigInt[24, size=1](8_388_607), 8_388_607)
+    _assert_equal(BigInt[24, size=1](-1), -1)
+    _assert_equal(BigInt[24, size=1](-8_388_608), -8_388_608)
 
-    _assert_equal(BigUInt[8, size=1](-1), 255)
-    _assert_equal(BigUInt[24, size=1](-1), 16_777_215)
+    _assert_equal(BigUInt[8, size=1](0), 0)
+    _assert_equal(BigUInt[8, size=1](255), 255)
+    _assert_equal(BigUInt[24, size=1](0), 0)
+    _assert_equal(BigUInt[24, size=1](16_777_215), 16_777_215)
+
+
+fn test_init_from_int() raises:
+    _assert_equal(BigInt[8, size=1](Int(1)), 1)
+    _assert_equal(BigInt[24, size=1](Int(1)), 1)
+
+    _assert_equal(BigUInt[8, size=1](Int(255)), 255)
+    _assert_equal(BigUInt[24, size=1](Int(16_777_215)), 16_777_215)
 
 
 fn test_init_from_signed_simd() raises:
@@ -562,6 +578,7 @@ fn test_is_zero() raises:
 fn main() raises:
     test_init()
     test_init_unsafe()
+    test_init_from_int_literal()
     test_init_from_int()
     test_init_from_signed_simd()
     test_init_from_unsigned_simd()


### PR DESCRIPTION
This PR introduces new functionality to the `BigInt` struct, enabling initialization with IntLiteral values. 